### PR TITLE
Add support for 8Bitdo SN30Pro under Chrome OS

### DIFF
--- a/mappings/index.js
+++ b/mappings/index.js
@@ -22,5 +22,7 @@ module.exports = [
   require("./ps4-chrome-windows-osx.json"),
   require("./ps4-ff-linux.json"),
   require("./ps4-ff-osx.json"),
-  require("./shitty-wheel.json")
+  require("./shitty-wheel.json"),
+  
+  require("./sn30pro-chrome-cros.json")
 ];

--- a/mappings/sn30pro-chrome-cros.json
+++ b/mappings/sn30pro-chrome-cros.json
@@ -1,0 +1,122 @@
+{
+  "axes": {
+    "dpad x": {
+      "index": 6
+    },
+    "dpad y": {
+      "index": 7
+    },
+    "left stick x": {
+      "index": 0
+    },
+    "left stick y": {
+      "index": 1
+    },
+    "right stick x": {
+      "index": 2
+    },
+    "right stick y": {
+      "index": 3
+    },
+    "left trigger": {
+      "buttonAnalog": 8
+    },
+    "right trigger": {
+      "buttonAnalog": 9
+    }
+  },
+  "buttons": {
+    "a": {
+      "index": 1
+    },
+    "b": {
+      "index": 0
+    },
+    "back": {
+      "index": 10
+    },
+    "dpad down": {
+      "axis": 6,
+      "direction": 1
+    },
+    "dpad left": {
+      "axis": 7,
+      "direction": -1
+    },
+    "dpad right": {
+      "axis": 7,
+      "direction": 1
+    },
+    "dpad up": {
+      "axis": 6,
+      "direction": -1
+    },
+    "home": {
+      "index": 2
+    },
+    "left shoulder": {
+      "index": 6
+    },
+    "left stick": {
+      "index": 13
+    },
+    "left stick down": {
+      "axis": 1,
+      "direction": 1
+    },
+    "left stick left": {
+      "axis": 0,
+      "direction": -1
+    },
+    "left stick right": {
+      "axis": 0,
+      "direction": 1
+    },
+    "left stick up": {
+      "axis": 1,
+      "direction": -1
+    },
+    "left trigger": {
+      "index": 8
+    },
+    "right shoulder": {
+      "index": 7
+    },
+    "right stick": {
+      "index": 14
+    },
+    "right stick down": {
+      "axis": 3,
+      "direction": 1
+    },
+    "right stick left": {
+      "axis": 2,
+      "direction": -1
+    },
+    "right stick right": {
+      "axis": 2,
+      "direction": 1
+    },
+    "right stick up": {
+      "axis": 3,
+      "direction": -1
+    },
+    "start": {
+      "index": 11
+    },
+    "x": {
+      "index": 4
+    },
+    "y": {
+      "index": 3
+    }
+  },
+  "name": "8Bitdo SN30 Pro CrOS",
+  "supported": [
+    {
+      "browser": "Chrome",
+      "id": "8Bitdo SN30 Pro (Vendor: 2dc8 Product: 6101)",
+      "os": "CrOS"
+    }
+  ]
+}


### PR DESCRIPTION
Hey all!

I noticed that there wasn't any builtin support for my favorite controller on my favorite operating system, so I took the time to put together the required configuration. I'm not sure how to test it aside from having utilized http://html5gamepad.com/ and using the output from that to determine which buttons and axes to use. Let me know if there's more testing I can do, or if you just want to push this one out to Rainway and let me give it a shot. I love what you guys are doing, but currently the gamepad I have is unusable in Chrome OS. (This configuration likely works in Chrome for Windows as well, but I haven't verified.)

Thanks!
justathoughtor2