### PR TITLE
Add mapping for Nintendo Switch Pro Controller

### DIFF
--- a/mappings/index.js
+++ b/mappings/index.js
@@ -24,5 +24,7 @@ module.exports = [
   require("./ps4-ff-osx.json"),
   require("./shitty-wheel.json"),
   
-  require("./sn30pro-chrome-cros.json")
+  require("./sn30pro-chrome-cros.json"),
+  
+  require("./switchpro-ff-windows.json")
 ];

--- a/mappings/switchpro-ff-windows.json
+++ b/mappings/switchpro-ff-windows.json
@@ -1,0 +1,118 @@
+{
+  "axes": {
+    "dpad x": {
+      "index": 6
+    },
+    "dpad y": {
+      "index": 7
+    },
+    "left stick x": {
+      "index": 0
+    },
+    "left stick y": {
+      "index": 1
+    },
+    "right stick x": {
+      "index": 2
+    },
+    "right stick y": {
+      "index": 3
+    },
+    "right trigger": {
+      "index": 5
+    }
+  },
+  "buttons": {
+    "b": {
+      "index": 0
+    },
+    "back": {
+      "index": 8
+    },
+    "dpad down": {
+      "index": 13
+    },
+    "dpad left": {
+      "index": 14
+    },
+    "dpad right": {
+      "index": 15
+    },
+    "dpad up": {
+      "index": 12
+    },
+    "home": {
+      "index": 16
+    },
+    "left shoulder": {
+      "index": 4
+    },
+    "left stick": {
+      "index": 10
+    },
+    "left stick down": {
+      "axis": 1,
+      "direction": 1
+    },
+    "left stick left": {
+      "axis": 0,
+      "direction": -1
+    },
+    "left stick right": {
+      "axis": 0,
+      "direction": 1
+    },
+    "left stick up": {
+      "axis": 1,
+      "direction": -1
+    },
+    "left trigger": {
+      "index": 6
+    },
+    "right shoulder": {
+      "index": 5
+    },
+    "right stick": {
+      "index": 11
+    },
+    "right stick down": {
+      "axis": 3,
+      "direction": 1
+    },
+    "right stick left": {
+      "axis": 2,
+      "direction": -1
+    },
+    "right stick right": {
+      "axis": 2,
+      "direction": 1
+    },
+    "right stick up": {
+      "axis": 3,
+      "direction": -1
+    },
+    "right trigger": {
+      "index": 7
+    },
+    "start": {
+      "index": 9
+    },
+    "x": {
+      "index": 3
+    },
+    "a": {
+      "index": 1
+    },
+    "y": {
+      "index": 2
+    }
+  },
+  "name": "057e-2009-Wireless Gamepad Chrome Windows NT",
+  "supported": [
+    {
+      "browser": "Chrome",
+      "id": "057e-2009-Wireless Gamepad",
+      "os": "Windows NT"
+    }
+  ]
+}


### PR DESCRIPTION
I have created a set of mappings with https://ericlathrop.github.io/html5-gamepad-configurator/ on firefox on windows and them put them in there own .json file under /mappings/ and added them to /mappings/index.js.

My aim here is to create a mapping for the switch pro controller that has the results respect the lables on the controllers buttons, where compaired to an xbox controller, the A and B and X and Y buttons are switched.

I am unsure about quite how this project works, so I have created this PR after looking at previous commits. Please have a look at my commits before merging them.

This PR should fix https://github.com/RainwayApp/html5-gamepad/issues/3 that I created.